### PR TITLE
Fix incorrect metrics for HPA autoscaling

### DIFF
--- a/k8/autoscaling/hpa_cart.yaml
+++ b/k8/autoscaling/hpa_cart.yaml
@@ -23,10 +23,10 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment

--- a/k8/autoscaling/hpa_creditinstitute.yaml
+++ b/k8/autoscaling/hpa_creditinstitute.yaml
@@ -23,10 +23,10 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment

--- a/k8/autoscaling/hpa_inventory.yaml
+++ b/k8/autoscaling/hpa_inventory.yaml
@@ -23,10 +23,10 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment

--- a/k8/autoscaling/hpa_orchestrator.yaml
+++ b/k8/autoscaling/hpa_orchestrator.yaml
@@ -23,10 +23,10 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment

--- a/k8/autoscaling/hpa_order.yaml
+++ b/k8/autoscaling/hpa_order.yaml
@@ -23,10 +23,10 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment

--- a/k8/autoscaling/hpa_payment.yaml
+++ b/k8/autoscaling/hpa_payment.yaml
@@ -23,10 +23,10 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment

--- a/k8/autoscaling/hpa_uibackend.yaml
+++ b/k8/autoscaling/hpa_uibackend.yaml
@@ -23,10 +23,10 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment
   - type: Resource
     resource:
       name: memory
       target:
         type: Utilization
-        averageUtilization: 50
+        averageUtilization: 100 # % of "request"s limit defined in the deployment

--- a/k8/cart.yaml
+++ b/k8/cart.yaml
@@ -47,6 +47,6 @@ spec:
               cpu: 500m
               memory: 500Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 250m
+              memory: 250Mi
       restartPolicy: Always

--- a/k8/cdcservice.yaml
+++ b/k8/cdcservice.yaml
@@ -63,6 +63,6 @@ spec:
               cpu: 500m
               memory: 500Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 250m
+              memory: 250Mi
       restartPolicy: Always

--- a/k8/creditinstitute.yaml
+++ b/k8/creditinstitute.yaml
@@ -62,6 +62,6 @@ spec:
               cpu: 500m
               memory: 500Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 250m
+              memory: 250Mi
       restartPolicy: Always

--- a/k8/inventory.yaml
+++ b/k8/inventory.yaml
@@ -67,6 +67,6 @@ spec:
               cpu: 500m
               memory: 500Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 250m
+              memory: 250Mi
       restartPolicy: Always

--- a/k8/orchestrator.yaml
+++ b/k8/orchestrator.yaml
@@ -57,6 +57,6 @@ spec:
               cpu: 500m
               memory: 500Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 250m
+              memory: 250Mi
       restartPolicy: Always

--- a/k8/order.yaml
+++ b/k8/order.yaml
@@ -59,6 +59,6 @@ spec:
               cpu: 500m
               memory: 500Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 250m
+              memory: 250Mi
       restartPolicy: Always

--- a/k8/payment.yaml
+++ b/k8/payment.yaml
@@ -61,6 +61,6 @@ spec:
               cpu: 500m
               memory: 500Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 250m
+              memory: 250Mi
       restartPolicy: Always

--- a/k8/ui.yaml
+++ b/k8/ui.yaml
@@ -41,6 +41,6 @@ spec:
               cpu: 500m
               memory: 500Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 250m
+              memory: 250Mi
       restartPolicy: Always

--- a/k8/uibackend.yaml
+++ b/k8/uibackend.yaml
@@ -49,6 +49,6 @@ spec:
               cpu: 500m
               memory: 500Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: 250m
+              memory: 250Mi
       restartPolicy: Always


### PR DESCRIPTION
I previously misunderstood the calculation completely:
The percentage isn't calculated according to the maximum of a metric, but to the minimum (`requests` key) instead.